### PR TITLE
Return after redirecting to blog post

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = (request, response) => {
     })
 
     response.end()
+    return
   }
 
   if (urlParts.length < 3) {


### PR DESCRIPTION
Added a missing return statement after `response.end()`.